### PR TITLE
feat: add session health command (wc_sessionPing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ See [SKILL.md](SKILL.md) for the skill specification and agent workflow.
 - Solana DeFi tokens
 
 ### Protocol Improvements
-- Session health monitoring and auto-reconnect
+- ✅ Session health monitoring (`health` command with `wc_sessionPing` + `--clean`)
 - Batch transaction support
 - EIP-712 typed data signing
 - Transaction simulation before sending (Tenderly, Blowfish)

--- a/SKILL.md
+++ b/SKILL.md
@@ -31,9 +31,10 @@ wallet-connect-skill/
 │       ├── helpers.mjs   # Shared utils (ENS, timeout, encoding, account lookup)
 │       ├── pair.mjs      # Pairing command
 │       ├── auth.mjs      # Authentication (consent sign)
-│       ├── sign.mjs      # Message signing (EVM + Solana)
-│       ├── send-tx.mjs   # Transaction sending (native + token, EVM + Solana)
-│       └── tokens.mjs    # Token metadata (addresses, decimals)
+│       ├── health.mjs           # Session health detection (wc_ping)
+│       ├── sign.mjs             # Message signing (EVM + Solana)
+│       ├── send-tx.mjs          # Transaction sending (native + token, EVM + Solana)
+│       └── tokens.mjs           # Token metadata (addresses, decimals)
 └── references/
     └── chains.md         # Supported chain IDs and tokens
 ```
@@ -106,6 +107,35 @@ node scripts/wallet.mjs delete-session --address 0xADDRESS
 ```
 Removes the session from `~/.agent-wallet/sessions.json`.
 Output: `{ status: "deleted", topic, peerName, accounts }`
+
+### Check Session Health
+```bash
+# Ping a specific session
+node scripts/wallet.mjs health --topic <topic>
+node scripts/wallet.mjs health --address 0xADDR
+
+# Ping all sessions
+node scripts/wallet.mjs health --all
+
+# Ping all and remove dead sessions automatically
+node scripts/wallet.mjs health --all --clean
+```
+
+Output:
+```json
+{
+  "checked": 2,
+  "alive": 1,
+  "dead": 1,
+  "cleaned": 1,
+  "sessions": [
+    { "topic": "abc123…", "peerName": "Gem Wallet", "accounts": ["0xC36ed…"], "alive": true },
+    { "topic": "def456…", "peerName": "MetaMask", "accounts": ["0xABC…"], "alive": false, "error": "ping timeout" }
+  ]
+}
+```
+
+Uses `wc_sessionPing` (15s timeout per session). A dead session means the wallet is offline or the session was disconnected — safe to `--clean`.
 
 ### Send Transaction
 ```bash

--- a/scripts/lib/health.mjs
+++ b/scripts/lib/health.mjs
@@ -1,0 +1,126 @@
+/**
+ * Session health command — ping a WalletConnect session to check liveness.
+ *
+ * Uses SignClient.ping({ topic }) which sends a wc_sessionPing request to the
+ * connected wallet. Resolves if the wallet responds within the timeout, rejects
+ * (or times out) if the session is stale / peer is offline.
+ *
+ * Options:
+ *   --topic <topic>    Check a specific session by topic
+ *   --address <0x...>  Check the session that owns this address
+ *   --all              Ping all known sessions (reports each)
+ *   --clean            Remove dead sessions from sessions.json
+ */
+
+import { getClient, loadSessions, saveSessions, findSessionByAddress } from "./client.mjs";
+import { redactAddress } from "./helpers.mjs";
+
+const PING_TIMEOUT_MS = 15000; // 15s — wallets are usually fast to pong
+
+/**
+ * Ping a single session topic. Returns { alive: bool, error?: string }.
+ */
+async function pingSession(client, topic) {
+  try {
+    await Promise.race([
+      client.ping({ topic }),
+      new Promise((_, reject) =>
+        setTimeout(() => reject(new Error("ping timeout")), PING_TIMEOUT_MS),
+      ),
+    ]);
+    return { alive: true };
+  } catch (err) {
+    return { alive: false, error: err.message };
+  }
+}
+
+export async function cmdHealth(args) {
+  const sessions = loadSessions();
+
+  // Resolve which topics to ping
+  let topics = [];
+
+  if (args.all) {
+    topics = Object.keys(sessions);
+    if (topics.length === 0) {
+      console.log(JSON.stringify({ status: "no_sessions", message: "No sessions found" }));
+      process.exit(0);
+    }
+  } else if (args.topic) {
+    if (!sessions[args.topic]) {
+      console.error(JSON.stringify({ error: "Session not found", topic: args.topic }));
+      process.exit(1);
+    }
+    topics = [args.topic];
+  } else if (args.address) {
+    const match = findSessionByAddress(sessions, args.address);
+    if (!match) {
+      console.error(JSON.stringify({ error: "No session found for address", address: args.address }));
+      process.exit(1);
+    }
+    topics = [match.topic];
+  } else {
+    console.error(
+      JSON.stringify({ error: "--topic, --address, or --all required for health command" }),
+    );
+    process.exit(1);
+  }
+
+  const client = await getClient();
+  const results = [];
+  const deadTopics = [];
+
+  for (const topic of topics) {
+    const session = sessions[topic];
+    const accounts = session.accounts || [];
+    const peerName = session.peerName || "unknown";
+
+    process.stderr.write(
+      JSON.stringify({ pinging: topic, peer: peerName }) + "\n",
+    );
+
+    const { alive, error } = await pingSession(client, topic);
+
+    const shortAddresses = accounts.map((a) => {
+      const parts = a.split(":");
+      return redactAddress(parts.slice(2).join(":"));
+    });
+
+    const entry = {
+      topic: topic.slice(0, 16) + "…",
+      fullTopic: topic,
+      peerName,
+      accounts: shortAddresses,
+      alive,
+      ...(error && { error }),
+    };
+
+    results.push(entry);
+
+    if (!alive) {
+      deadTopics.push(topic);
+    }
+  }
+
+  // Clean dead sessions if requested
+  let cleaned = 0;
+  if (args.clean && deadTopics.length > 0) {
+    const updated = { ...sessions };
+    for (const t of deadTopics) {
+      delete updated[t];
+    }
+    saveSessions(updated);
+    cleaned = deadTopics.length;
+  }
+
+  const output = {
+    checked: results.length,
+    alive: results.filter((r) => r.alive).length,
+    dead: results.filter((r) => !r.alive).length,
+    ...(args.clean && { cleaned }),
+    sessions: results,
+  };
+
+  console.log(JSON.stringify(output, null, 2));
+  await client.core.relayer.transportClose();
+}

--- a/scripts/wallet.mjs
+++ b/scripts/wallet.mjs
@@ -14,6 +14,7 @@
  *   list-sessions    List sessions with accounts, peer, and date
  *   whoami           Show account info for a session
  *   delete-session   Remove a saved session
+ *   health           Ping session(s) to check liveness (--all, --clean)
  */
 
 import { parseArgs } from "util";
@@ -22,6 +23,7 @@ import { cmdAuth } from "./lib/auth.mjs";
 import { cmdSign } from "./lib/sign.mjs";
 import { cmdSendTx } from "./lib/send-tx.mjs";
 import { cmdBalance } from "./lib/balance.mjs";
+import { cmdHealth } from "./lib/health.mjs";
 import { loadSessions, saveSessions, findSessionByAddress } from "./lib/client.mjs";
 import { getTokensForChain } from "./lib/tokens.mjs";
 
@@ -200,6 +202,9 @@ const { positionals, values } = parseArgs({
     to: { type: "string" },
     amount: { type: "string" },
     token: { type: "string" },
+    data: { type: "string" },
+    all: { type: "boolean" },
+    clean: { type: "boolean" },
     help: { type: "boolean", short: "h" },
   },
 });
@@ -221,9 +226,12 @@ Commands:
   list-sessions    List sessions (human-readable)
   whoami           Show account info (--topic <topic> | --address <addr>)
   delete-session   Remove a saved session (--topic <topic> | --address <addr>)
+  health           Ping session to check liveness (--topic | --address | --all) [--clean]
 
 Options:
-  --address <0x...>  Select session by wallet address (case-insensitive)`);
+  --address <0x...>  Select session by wallet address (case-insensitive)
+  --all              (health) Ping all sessions
+  --clean            (health) Remove dead sessions from storage`);
   process.exit(0);
 }
 
@@ -251,6 +259,7 @@ const commands = {
   "list-sessions": cmdListSessions,
   whoami: cmdWhoami,
   "delete-session": cmdDeleteSession,
+  health: cmdHealth,
 };
 
 if (!commands[command]) {


### PR DESCRIPTION
Implements session health detection via WalletConnect's ping protocol.

## Changes
- New `health` command in `scripts/lib/health.mjs`
- Sends `wc_sessionPing` to check if a wallet session is still alive
- Supports `--topic`, `--address`, and `--all` (batch ping every saved session)
- `--clean` flag removes dead sessions from `~/.agent-wallet/sessions.json` automatically
- 15s timeout per ping; exits cleanly with structured JSON output
- Updated SKILL.md with usage docs and project structure
- Marked session health monitoring as done in README roadmap

## Usage
```bash
# Ping one session
node scripts/wallet.mjs health --address 0xC36edF48...

# Batch ping + remove dead sessions
node scripts/wallet.mjs health --all --clean
```

## Output
```json
{
  "checked": 2, "alive": 1, "dead": 1, "cleaned": 1,
  "sessions": [{ "topic": "abc123…", "peerName": "Gem Wallet", "alive": true }, ...]
}
```

Part of the roadmap: Session health monitoring and auto-reconnect.